### PR TITLE
metadata responses

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -41,14 +41,13 @@ def duckdb_router() -> APIRouter:
 
     @router.post("/duckdb")
     async def execute_query(req: DuckDbQueryRequest) -> DuckDbQueryResponse:
-        tic = time.perf_counter()
-        df: pd.DataFrame = duck_core.execute_as_df(query_str=req.query_str)
-        toc = time.perf_counter()
-        print(f"{toc-tic} secs")
+        df, df_meta = duck_core.execute_as_df_with_meta_data(query_str=req.query_str)
 
         return DuckDbQueryResponse(
-            data=df.to_dict(orient="list")
+            data=df.to_dict(orient="list"),
+            metadata=df_meta.to_dict(orient="list")
         )
+
     return router
 
 

--- a/api/types.py
+++ b/api/types.py
@@ -28,4 +28,5 @@ class DuckDbQueryResponse(BaseModel):
     # Another note: After implementing this solution, select * from president_polls went from ~40ms to ~70ms for
     #               a warmed-up approx latency metric. There is not enough info at this time to conclude it's due to
     #               the serialization, as the "columns 'just json string'" format was about 50% greater, in bytes
-    data: t.Dict[str, t.List[t.Union[Decimal, pd.Timestamp, str]]]
+    data:     t.Dict[str, t.List[t.Union[Decimal, pd.Timestamp, str]]]
+    metadata: t.Dict[str, t.List[t.Union[Decimal, pd.Timestamp, str]]]

--- a/tests/duck_wrapper_test.py
+++ b/tests/duck_wrapper_test.py
@@ -37,3 +37,12 @@ def test_execute_as_df(duck_core_preloaded: DuckCore) -> None:
     """
     df = duck_core_preloaded.execute_as_df(query_str=query)
     assert len(df) > 100
+
+
+def test_execute_as_df_with_meta_data(duck_core_preloaded: DuckCore) -> None:
+    query = "select p.population, sample_size, sponsor_candidate, stage from president_polls_historical p"
+    df, df_meta = duck_core_preloaded.execute_as_df_with_meta_data(query_str=query)
+
+    assert len(df) > 100
+    assert "population" in df.columns
+    assert "population" in df_meta["column_name"].tolist()


### PR DESCRIPTION
By creating a view of the desired query, then DESCRIBE-ing that view, we can return enough metadata for elm-vega to do it's thing. I expect the specific shape to take a different shape, but this should be enough data / metadata