### PR TITLE
change permissions after copying code into image

### DIFF
--- a/Dockerfile-Deployment
+++ b/Dockerfile-Deployment
@@ -1,5 +1,7 @@
 FROM robsoko-api:dev
 
+# Since the service writes to its own home directory, we must grant ownership of the data we're about to copy in
+# Mounting a drive during dev implicitly achieves this, which is why we only do this operation in the deployed version
 USER root
 COPY ./ /home/appuser
 RUN chown -R appuser /home/appuser

--- a/Dockerfile-Deployment
+++ b/Dockerfile-Deployment
@@ -1,4 +1,8 @@
 FROM robsoko-api:dev
 
+USER root
 COPY ./ /home/appuser
+RUN chown -R appuser /home/appuser
+USER appuser
+
 CMD ["sh", "-c", "gunicorn --workers 4 --timeout 3600 --worker-class uvicorn.workers.UvicornWorker -b 0.0.0.0:8080 api.server:app"]


### PR DESCRIPTION
First issue where local dev / prod variation mattered.

It was related to permissions, since internally the blob storage writes to disk.

What's good though is the docker-compose `api-gunicorn` service did repro this issue locally!!

