### PR TITLE
Slimer package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,8 @@
 
-temp/
 tests/temp/
 tests/.pytest_cache/
 .pytest_cache/
 __pycache__/
 **/__pycache__/
+
+.parquet

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,7 @@
 
+temp/
 tests/temp/
 tests/.pytest_cache/
 .pytest_cache/
+__pycache__/
+**/__pycache__/

--- a/Dockerfile-Deployment
+++ b/Dockerfile-Deployment
@@ -4,7 +4,13 @@ FROM robsoko-api:dev
 # Mounting a drive during dev implicitly achieves this, which is why we only do this operation in the deployed version
 USER root
 COPY ./ /home/appuser
-RUN chown -R appuser /home/appuser
+
+# splitting this out into multi-stage build and using the COPY command in this manner somehow reduces final image size
+# source: https://garbers.co.za/2017/11/15/reduce-docker-image-size-chmod-chown/#:~:text=Traditionally%2C%20copying%20in%20large%20files,of%20the%20files%20being%20modified).
+FROM robsoko-api:dev
+
+USER root
+COPY --from=0 --chown=appuser:appuser /home/appuser /home/appuser
 USER appuser
 
 CMD ["sh", "-c", "gunicorn --workers 1 --timeout 3600 --worker-class uvicorn.workers.UvicornWorker -b 0.0.0.0:8080 api.server:app"]

--- a/tests/api_tests/http_api_test.py
+++ b/tests/api_tests/http_api_test.py
@@ -10,8 +10,8 @@ TEST_TEMP_DIR = "./tests/temp"
 
 # TODO: When I do the CloudBuild work these should be set via env files
 # TARGET_HOST = "http://localhost:8000"  # local dev
-# TARGET_HOST = "http://host.docker.internal:8080"  # local gunicorn
-TARGET_HOST = "https://api.robsoko.tech"  # production
+TARGET_HOST = "http://host.docker.internal:8080"  # local gunicorn
+# TARGET_HOST = "https://api.robsoko.tech"  # production
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
reduces final image size a few hundred MB, by `.dockerignore`ing a few things, and a wild quirk I found: https://garbers.co.za/2017/11/15/reduce-docker-image-size-chmod-chown/#:~:text=Traditionally%2C%20copying%20in%20large%20files,of%20the%20files%20being%20modified).

However, this is still too large a delta from `dev` to `prod` image sizes. While this has no downside, it isn't a big a gain I was hoping for.

The bigger gain is build time, which went from 30 secs to 7-8